### PR TITLE
downscale discontinuity

### DIFF
--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -6,16 +6,16 @@ using DataFrames
 include("getpagefunction.jl")
 include("utils/mctools.jl")
 
-m = getpage() 
+m = getpage()
 run(m)
 
 mcs = @defmcs begin
-        
+
     ############################################################################
-    # Define random variables (RVs) 
+    # Define random variables (RVs)
     ############################################################################
-    
-    #The folllowing RVs are in more than one component.  For clarity they are 
+
+    #The folllowing RVs are in more than one component.  For clarity they are
     #set here as opposed to below within the blocks of RVs separated by component
     #so that they are not set more than once.
 
@@ -30,7 +30,7 @@ mcs = @defmcs begin
     wincf_weightsfactor["LatAmerica"] = TriangularDist(.4, .8, .6)
 
     automult_autonomouschange = TriangularDist(0.5, 0.8, 0.65)  #components: AdaptationCosts, AbatementCosts
-    
+
     #The following RVs are divided into blocks by component
 
     # CO2cycle
@@ -39,26 +39,26 @@ mcs = @defmcs begin
     ccf_CO2feedback = TriangularDist(4, 15, 10)
     ccfmax_maxCO2feedback = TriangularDist(30, 80, 50)
     stay_fractionCO2emissionsinatm = TriangularDist(0.25,0.35,0.3)
-    
+
     # SulphateForcing
     d_sulphateforcingbase = TriangularDist(-0.8, -0.2, -0.4)
     ind_slopeSEforcing_indirect = TriangularDist(-0.8, 0, -0.4)
-    
+
     # ClimateTemperature
     rlo_ratiolandocean = TriangularDist(1.2, 1.6, 1.4)
     pole_polardifference = TriangularDist(1, 2, 1.5)
     frt_warminghalflife = TriangularDist(10, 65, 30)
     tcr_transientresponse = TriangularDist(1, 2.8, 1.3)
-    
+
     # SeaLevelRise
     s0_initialSL = TriangularDist(0.1, 0.2, 0.15)
     sltemp_SLtemprise = TriangularDist(0.7, 3., 1.5)
     sla_SLbaselinerise = TriangularDist(0.5, 1.5, 1.)
     sltau_SLresponsetime = TriangularDist(500, 1500, 1000)
-    
+
     # GDP
-    isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30) 
-    
+    isat0_initialimpactfxnsaturation = TriangularDist(20, 50, 30)
+
     # MarketDamages
     tcal_CalibrationTemp = TriangularDist(2.5, 3.5, 3.)
     iben_MarketInitialBenefit = TriangularDist(0, .3, .1)
@@ -72,61 +72,61 @@ mcs = @defmcs begin
     w_NonImpactsatCalibrationTemp = TriangularDist(.1, 1, .5)
     pow_NonMarketExponent = TriangularDist(1.5, 3, 2)
     ipow_NonMarketIncomeFxnExponent = TriangularDist(-.2, .2, 0)
-    
+
     # SLRDamages
     scal_calibrationSLR = TriangularDist(0.45, 0.55, .5)
     #iben_SLRInitialBenefit = TriangularDist(0, 0, 0) # only usable if lb <> ub
     W_SatCalibrationSLR = TriangularDist(.5, 1.5, 1)
     pow_SLRImpactFxnExponent = TriangularDist(.5, 1, .7)
     ipow_SLRIncomeFxnExponent = TriangularDist(-.4, -.2, -.3)
-    
+
     # Discountinuity
     rand_discontinuity = Uniform(0, 1)
-    tdis_tolerabilitydisc = TriangularDist(2, 4, 3)
+    tdis_tolerabilitydisc = TriangularDist(1, 2, 1.5)
     pdis_probability = TriangularDist(10, 30, 20)
-    wdis_gdplostdisc = TriangularDist(5, 25, 15)
+    wdis_gdplostdisc = TriangularDist(1, 5, 3)
     ipow_incomeexponent = TriangularDist(-.3, 0, -.1)
-    distau_discontinuityexponent = TriangularDist(20, 200, 50)
-    
+    distau_discontinuityexponent = TriangularDist(10, 30, 20)
+
     # EquityWeighting
     civvalue_civilizationvalue = TriangularDist(1e10, 1e11, 5e10)
     ptp_timepreference = TriangularDist(0.1,2,1)
     emuc_utilityconvexity = TriangularDist(0.5,2,1)
-    
+
     # AbatementCosts
     AbatementCostsCO2_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,75,0)
     AbatementCostsCH4_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-25,100,0)
     AbatementCostsN2O_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
     AbatementCostsLin_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-50,50,0)
-    
+
     AbatementCostsCO2_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,40,20)
     AbatementCostsCH4_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
     AbatementCostsN2O_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
     AbatementCostsLin_q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = TriangularDist(0,20,10)
-    
+
     AbatementCostsCO2_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
     AbatementCostsCH4_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-8000,-1000,-4000)
     AbatementCostsN2O_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-15000,0,-7000)
     AbatementCostsLin_c0init_MostNegativeCostCutbackinBaseYear = TriangularDist(-400,-100,-200)
-    
+
     AbatementCostsCO2_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
     AbatementCostsCH4_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
     AbatementCostsN2O_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(35,70,50)
     AbatementCostsLin_qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = TriangularDist(60,80,70)
-    
+
     AbatementCostsCO2_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,700,400)
     AbatementCostsCH4_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(3000,10000,6000)
     AbatementCostsN2O_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(2000,60000,20000)
     AbatementCostsLin_cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = TriangularDist(100,600,300)
-    
+
     AbatementCostsCO2_ies_InitialExperienceStockofCutbacks = TriangularDist(100000,200000,150000)
     AbatementCostsCH4_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
     AbatementCostsN2O_ies_InitialExperienceStockofCutbacks = TriangularDist(30,80,50)
     AbatementCostsLin_ies_InitialExperienceStockofCutbacks = TriangularDist(1500,2500,2000)
-    
+
     #the following variables need to be set, but set the same in all 4 abatement cost components
     #note that for these regional variables, the first region is the focus region (EU), which is set in the preceding code, and so is always one for these variables
-    
+
     emitf_uncertaintyinBAUemissfactor["USA"] = TriangularDist(0.8,1.2,1.0)
     emitf_uncertaintyinBAUemissfactor["OECD"] = TriangularDist(0.8,1.2,1.0)
     emitf_uncertaintyinBAUemissfactor["USSR"] = TriangularDist(0.65,1.35,1.0)
@@ -134,15 +134,15 @@ mcs = @defmcs begin
     emitf_uncertaintyinBAUemissfactor["SEAsia"] = TriangularDist(0.5,1.5,1.0)
     emitf_uncertaintyinBAUemissfactor["Africa"] = TriangularDist(0.5,1.5,1.0)
     emitf_uncertaintyinBAUemissfactor["LatAmerica"] = TriangularDist(0.5,1.5,1.0)
-    
+
     q0f_negativecostpercentagefactor["USA"] = TriangularDist(0.75,1.5,1.0)
     q0f_negativecostpercentagefactor["OECD"] = TriangularDist(0.75,1.25,1.0)
-    q0f_negativecostpercentagefactor["USSR"] = TriangularDist(0.4,1.0,0.7)      
+    q0f_negativecostpercentagefactor["USSR"] = TriangularDist(0.4,1.0,0.7)
     q0f_negativecostpercentagefactor["China"] = TriangularDist(0.4,1.0,0.7)
     q0f_negativecostpercentagefactor["SEAsia"] = TriangularDist(0.4,1.0,0.7)
     q0f_negativecostpercentagefactor["Africa"] = TriangularDist(0.4,1.0,0.7)
     q0f_negativecostpercentagefactor["LatAmerica"] = TriangularDist(0.4,1.0,0.7)
-    
+
     cmaxf_maxcostfactor["USA"] = TriangularDist(0.8,1.2,1.0)
     cmaxf_maxcostfactor["OECD"] = TriangularDist(1.0,1.5,1.2)
     cmaxf_maxcostfactor["USSR"] = TriangularDist(0.4,1.0,0.7)
@@ -150,7 +150,7 @@ mcs = @defmcs begin
     cmaxf_maxcostfactor["SEAsia"] = TriangularDist(1,1.5,1.2)
     cmaxf_maxcostfactor["Africa"] = TriangularDist(1,1.5,1.2)
     cmaxf_maxcostfactor["LatAmerica"] = TriangularDist(0.4,1.0,0.7)
-    
+
     q0propmult_cutbacksatnegativecostinfinalyear = TriangularDist(0.3,1.2,0.7)
     qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear = TriangularDist(1,1.5,1.3)
     c0mult_mostnegativecostinfinalyear = TriangularDist(0.5,1.2,0.8)
@@ -158,7 +158,7 @@ mcs = @defmcs begin
     curve_above_curvatureofMACcurveabovezerocost = TriangularDist(0.1,0.7,0.4)
     cross_experiencecrossoverratio = TriangularDist(0.1,0.3,0.2)
     learn_learningrate = TriangularDist(0.05,0.35,0.2)
-    
+
     # AdaptationCosts
     AdaptiveCostsSeaLevel_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
     AdaptiveCostsSeaLevel_ci_costimpact_eu = TriangularDist(0.0005, 0.002, 0.001)
@@ -166,7 +166,7 @@ mcs = @defmcs begin
     AdaptiveCostsEconomic_ci_costimpact_eu = TriangularDist(0.001, 0.008, 0.003)
     AdaptiveCostsNonEconomic_cp_costplateau_eu = TriangularDist(0.01, 0.04, 0.02)
     AdaptiveCostsNonEconomic_ci_costimpact_eu = TriangularDist(0.002, 0.01, 0.005)
-    
+
     cf_costregional["USA"] = TriangularDist(0.6, 1, 0.8)
     cf_costregional["OECD"] = TriangularDist(0.4, 1.2, 0.8)
     cf_costregional["USSR"] = TriangularDist(0.2, 0.6, 0.4)
@@ -178,12 +178,12 @@ mcs = @defmcs begin
     ############################################################################
     # Indicate which parameters to save for each model run
     ############################################################################
-    
+
     save(EquityWeighting.td_totaldiscountedimpacts,
-        EquityWeighting.tpc_totalaggregatedcosts, 
+        EquityWeighting.tpc_totalaggregatedcosts,
         EquityWeighting.tac_totaladaptationcosts,
         EquityWeighting.te_totaleffect,
-        co2cycle.c_CO2concentration, 
+        co2cycle.c_CO2concentration,
         TotalForcing.ft_totalforcing,
         ClimateTemperature.rt_g_globaltemperature,
         SeaLevelRise.s_sealevel,
@@ -195,7 +195,7 @@ mcs = @defmcs begin
 end #defmcs
 
 #Reformat the RV results into the format used for testing
-function reformat_RV_outputs(samplesize::Int; outputpath::String = joinpath(@__DIR__, "../../output/"))         
+function reformat_RV_outputs(samplesize::Int; outputpath::String = joinpath(@__DIR__, "../../output/"))
 
     #create vectors to hold results of Monte Carlo runs
     td=zeros(samplesize);


### PR DESCRIPTION
As ice sheets are now explicitly modelled, the discontinuity damages have been downscaled.
The three parameters that have been changed are:
-  the tolerable GMST level tdis_tolerabilitydisc
-  the %GDP loss in case of a discontinuity wdis_gdplostdisc
-  the time-scale of the losses distau_discontinuityexponent
All parameters have new (lower) Monte Carlo parameters in msc.jl which result in new means in the deterministic model version in discontinuity.jl. No mean has >1 digit, so there should be no issue with the full precision of values.

#12  

@jrising How should we proceed with merging? Should we always merge your replacedata branch into our new branches, should I merge the most recent branch (msc_ClimateSensitivity)? Not sure which is the way to go.