### PR TITLE
fix distau in mcs.jl

### DIFF
--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -111,7 +111,7 @@ function getsim()
         pdis_probability = TriangularDist(10, 30, 20)
         wdis_gdplostdisc = TriangularDist(1, 5, 3)
         ipow_incomeexponent = TriangularDist(-.3, 0, -.1)
-        distau_discontinuityexponent = TriangularDist(20, 200, 50)
+        distau_discontinuityexponent = TriangularDist(10, 30, 20)
 
         # EquityWeighting
         civvalue_civilizationvalue = TriangularDist(1e10, 1e11, 5e10)


### PR DESCRIPTION
The distau parameter still uses the old PAGE09 distribution values for MC (although the default value for the deterministic run has already been set to the new PAGE-ICE value).

For a quick MC run with 1000 simulations, fixing the bug reduces the median SCC from $204 to $199.