### PR TITLE
Computes country-level emissions based on global carbon price

### DIFF
--- a/analysis/compare-co2.jl
+++ b/analysis/compare-co2.jl
@@ -1,0 +1,52 @@
+using CSV
+
+include("../src/climate_model.jl")
+
+alldf_clim = nothing
+for scenario in ["RCP1.9 & SSP1", "RCP2.6 & SSP1", "RCP4.5 & SSP2", "RCP8.5 & SSP5"]
+    mm = climatemodel(scenario)
+    run(mm)
+    df = getdataframe(mm, :co2emissions, :e_globalCO2emissions)
+    df[!, :scenario] .= scenario
+    if alldf_clim == nothing
+        alldf_clim = df
+    else
+        alldf_clim = [alldf_clim; df]
+    end
+end
+
+# CSV.write("old-co2.csv", alldf_clim)
+
+include("../src/main_model.jl")
+
+alldf_main = nothing
+for scenario in ["RCP1.9 & SSP1", "RCP2.6 & SSP1", "RCP4.5 & SSP2", "RCP8.5 & SSP5"]
+    mm = getpage(scenario)
+    run(mm)
+    df = getdataframe(mm, :co2emissions, :e_globalCO2emissions)
+    df[!, :scenario] .= scenario
+    cprice = mean(mm[:CarbonPriceInfer, :carbonprice], dims=2)
+    df[!, :cprice] .= cprice
+    if alldf_main == nothing
+        alldf_main = df
+    else
+        alldf_main = [alldf_main; df]
+    end
+end
+
+# CSV.write("new-co2.csv", alldf_main)
+
+using Plots
+
+scatter(alldf_clim.e_globalCO2emissions[alldf_clim.time .== 2020], alldf_main.e_globalCO2emissions[alldf_main.time .== 2020])
+scatter(alldf_clim.e_globalCO2emissions[alldf_clim.time .== 2100], alldf_main.e_globalCO2emissions[alldf_main.time .== 2100])
+scatter(alldf_clim.e_globalCO2emissions[(alldf_clim.e_globalCO2emissions .> 0) .& (alldf_main.e_globalCO2emissions .> 0)], alldf_main.e_globalCO2emissions[(alldf_clim.e_globalCO2emissions .> 0) .& (alldf_main.e_globalCO2emissions .> 0)])
+hcat(alldf_clim[(alldf_clim.e_globalCO2emissions .<= 0) .| (alldf_main.e_globalCO2emissions .<= 0), :], alldf_main[(alldf_clim.e_globalCO2emissions .<= 0) .| (alldf_main.e_globalCO2emissions .<= 0), :], makeunique=true)
+
+scatter(alldf_clim.e_globalCO2emissions, alldf_main.e_globalCO2emissions, markercolor=alldf_clim.scenario, label=nothing, xlabel="Regional emissions reductions", ylabel="Country-level response to carbon price")
+
+pp = scatter(alldf_clim.e_globalCO2emissions[alldf_clim.scenario .== "RCP1.9 & SSP1"], alldf_main.e_globalCO2emissions[alldf_clim.scenario .== "RCP1.9 & SSP1"], label="RCP1.9 & SSP1", xlabel="Regional emissions reductions", ylabel="Country-level response to carbon price")
+scatter!(pp, alldf_clim.e_globalCO2emissions[alldf_clim.scenario .== "RCP2.6 & SSP1"], alldf_main.e_globalCO2emissions[alldf_clim.scenario .== "RCP2.6 & SSP1"], label="RCP2.6 & SSP1", xlabel="Regional emissions reductions", ylabel="Country-level response to carbon price")
+scatter!(pp, alldf_clim.e_globalCO2emissions[alldf_clim.scenario .== "RCP4.5 & SSP2"], alldf_main.e_globalCO2emissions[alldf_clim.scenario .== "RCP4.5 & SSP2"], label="RCP4.5 & SSP2", xlabel="Regional emissions reductions", ylabel="Country-level response to carbon price")
+scatter!(pp, alldf_clim.e_globalCO2emissions[alldf_clim.scenario .== "RCP8.5 & SSP5"], alldf_main.e_globalCO2emissions[alldf_clim.scenario .== "RCP8.5 & SSP5"], label="RCP8.5 & SSP5", xlabel="Regional emissions reductions", ylabel="Country-level response to carbon price")
+savefig("compare-co2.pdf")

--- a/src/components/CO2emissions_national.jl
+++ b/src/components/CO2emissions_national.jl
@@ -1,0 +1,19 @@
+@defcomp co2emissions begin
+    country = Index()
+
+    baselineemit = Parameter(index=[time, country], unit="MtCO2/year")
+    fracabatedcarbon = Parameter(index=[time, country], unit="portion")
+
+    e_countryCO2emissions = Variable(index=[time,country], unit="Mtonne/year")
+    e_globalCO2emissions = Variable(index=[time], unit="Mtonne/year")
+
+    function run_timestep(p, v, d, t)
+
+        # eq.4 in Hope (2006) - regional CO2 emissions as % change from baseline
+        for cc in d.country
+            v.e_countryCO2emissions[t,cc] = p.baselineemit[t,cc] * (1 - p.fracabatedcarbon[t, cc])
+        end
+        # eq. 5 in Hope (2006) - global CO2 emissions are sum of regional emissions
+        v.e_globalCO2emissions[t] = sum(v.e_countryCO2emissions[t,:])
+    end
+end

--- a/src/main_model.jl
+++ b/src/main_model.jl
@@ -13,7 +13,7 @@ include("compute_scc.jl")
 
 include("components/RCPSSPScenario.jl")
 include("components/RFFSPScenario.jl")
-include("components/CO2emissions.jl")
+include("components/CO2emissions_national.jl")
 include("components/CO2cycle.jl")
 include("components/CO2forcing.jl")
 include("components/CH4emissions.jl")

--- a/src/models/climate_model_def.jl
+++ b/src/models/climate_model_def.jl
@@ -30,6 +30,7 @@ function climatemodel(scenario::String, use_permafrost::Bool=true, use_seaice::B
 
     # connect parameters together
     connect_param!(m, :GlobalTemperature => :fant_anthroforcing, :TotalForcing => :fant_anthroforcing)
+    regtemp[:rt_g_globaltemperature] = glotemp[:rt_g_globaltemperature]
 
     if use_permafrost
         permafrost_sibcasa[:rt_g] = glotemp[:rt_g_globaltemperature]
@@ -78,6 +79,7 @@ function climatemodel(scenario::String, use_permafrost::Bool=true, use_seaice::B
     connect_param!(m, :LGforcing => :c_LGconcentration, :LGcycle => :c_LGconcentration)
 
     sulfemit[:pse_sulphatevsbase] = scenario[:pse_sulphatevsbase]
+    sulfemit[:area_region] = regtemp[:area_region]
 
     connect_param!(m, :TotalForcing => :f_CO2forcing, :co2forcing => :f_CO2forcing)
     connect_param!(m, :TotalForcing => :f_CH4forcing, :ch4forcing => :f_CH4forcing)
@@ -85,6 +87,7 @@ function climatemodel(scenario::String, use_permafrost::Bool=true, use_seaice::B
     connect_param!(m, :TotalForcing => :f_lineargasforcing, :LGforcing => :f_LGforcing)
     totalforcing[:exf_excessforcing] = scenario[:exf_excessforcing]
     connect_param!(m, :TotalForcing => :fs_sulfateforcing, :SulphateForcing => :fs_sulphateforcing)
+    totalforcing[:area_region] = regtemp[:area_region]
 
     # next: add vector and panel example
     p = load_parameters(m)

--- a/src/models/main_model_def.jl
+++ b/src/models/main_model_def.jl
@@ -14,6 +14,18 @@ function buildpage(m::Model, scenario::String, use_permafrost::Bool=true, use_se
         socioscenario = scenario
         socioscenario_comp = :RCPSSPScenario
     end
+    carbonpriceinfer = addcarbonpriceinfer(m)
+
+    # Socio-Economics
+    population = addpopulation(m)
+    gdp = addgdp(m)
+
+    gdp[:pop0_initpopulation_region] = population[:pop0_initpopulation_region]
+
+    abateco2 = addabatementcostsco2(m)
+
+    abateco2[:e0_baselineCO2emissions_country] = carbonpriceinfer[:e0_baselineCO2emissions_country]
+
     glotemp = addglobaltemperature(m, use_seaice)
     regtemp = addregiontemperature(m)
     if use_permafrost
@@ -37,17 +49,10 @@ function buildpage(m::Model, scenario::String, use_permafrost::Bool=true, use_se
     totalforcing = add_comp!(m, TotalForcing)
     add_comp!(m, SeaLevelRise)
 
-    # Socio-Economics
-    population = addpopulation(m)
-    gdp = addgdp(m)
-
-    gdp[:pop0_initpopulation_region] = population[:pop0_initpopulation_region]
-
     # Abatement Costs
     addabatementcostparameters(m, :CH4)
     addabatementcostparameters(m, :N2O)
     addabatementcostparameters(m, :Lin)
-    carbonpriceinfer = addcarbonpriceinfer(m)
 
     set_param!(m, :q0propmult_cutbacksatnegativecostinfinalyear, 0.8833333333333333)
     set_param!(m, :qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear, 1.1166666666666666)
@@ -61,7 +66,6 @@ function buildpage(m::Model, scenario::String, use_permafrost::Bool=true, use_se
 
     set_param!(m, :automult_autonomoustechchange, .65)
 
-    abateco2 = addabatementcostsco2(m)
     addabatementcosts(m, :CH4)
     addabatementcosts(m, :N2O)
     addabatementcosts(m, :Lin)
@@ -102,7 +106,13 @@ function buildpage(m::Model, scenario::String, use_permafrost::Bool=true, use_se
         permafrost[:perm_jul_ce_ch4] = permafrost_jules[:perm_jul_ce_ch4]
     end
 
-    co2emit[:er_CO2emissionsgrowth] = scenario[:er_CO2emissionsgrowth]
+    carbonpriceinfer[:er_CO2emissionsgrowth] = socioscenario[:er_CO2emissionsgrowth]
+
+    abateco2[:carbonprice] = carbonpriceinfer[:carbonprice]
+    abateco2[:gdp] = gdp[:gdp]
+
+    co2emit[:baselineemit] = abateco2[:baselineemit]
+    co2emit[:fracabatedcarbon] = abateco2[:fracabatedcarbon]
 
     connect_param!(m, :CO2Cycle => :e_globalCO2emissions, :co2emissions => :e_globalCO2emissions)
     connect_param!(m, :CO2Cycle => :rt_g_globaltemperature, :GlobalTemperature => :rt_g_globaltemperature)
@@ -159,11 +169,6 @@ function buildpage(m::Model, scenario::String, use_permafrost::Bool=true, use_se
     connect_param!(m, :GDP => :pop_population, :Population => :pop_population)
     connect_param!(m, :GDP => :pop_population_region, :Population => :pop_population_region)
     gdp[:grw_gdpgrowthrate] = socioscenario[:grw_gdpgrowthrate]
-
-    carbonpriceinfer[:er_CO2emissionsgrowth] = socioscenario[:er_CO2emissionsgrowth]
-
-    abateco2[:carbonprice] = carbonpriceinfer[:carbonprice]
-    abateco2[:gdp] = gdp[:gdp]
 
     for allabatement in [
         (:AbatementCostParametersCH4, :AbatementCostsCH4, :er_CH4emissionsgrowth),

--- a/src/models/mcs_def.jl
+++ b/src/models/mcs_def.jl
@@ -189,7 +189,6 @@ function getsim()
         # AbatementCosts
         rv(RV_mac_draw) = DiscreteUniform(1, 100)
         AbatementCostsCO2_mac_draw = RV_mac_draw
-        AbatementCostsCO2_baselineco2_uniforms = Uniform(0, 1) # <-- Added after @defsim
 
         AbatementCostParametersCH4_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-67, 6.0, -30)
         AbatementCostParametersN2O_emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = TriangularDist(-20, 6.0, -7.0)
@@ -225,6 +224,7 @@ function getsim()
 
         # CarbonPriceInfer
         CarbonPriceInfer_mac_draw = RV_mac_draw
+        CarbonPriceInfer_baselineco2_uniforms = Uniform(0, 1) # <-- Added after @defsim
 
         ############################################################################
         # Indicate which parameters to save for each model run


### PR DESCRIPTION
This provides an alternative logic path for the main model (the climate-only model is left the same). Previously (and under the climate model), the Scenario informs `CO2Emissions` directly. Under this new path, the Scenario feeds into the `CarbonPriceInfer`, which goes to `AbatementCostsCO2`, and from that to `CO2Emissions`. This allows for country-level CO2 emissions.

This also updates the country-level empirical reductions equations so that the equation [empirical reduction] / (exp(-Price / 500) + [empirical reduction]) only applies to reductions less than 100% (because we still want to allow some countries to have negative emissions).

It also fixes the use of the empirical autoregressive term, and makes the carbon price inference exactly consistent with the emissions reduction calculations in `AbatementCostsCO2`.